### PR TITLE
Pass the latitude and longitude to JavaScript-land

### DIFF
--- a/MagnetScannerIOS/NetworkResolver.swift
+++ b/MagnetScannerIOS/NetworkResolver.swift
@@ -15,7 +15,6 @@ import SwiftyJSON
 //
 public class NetworkResolver {
   static let API_END_POINT: String = "https://tengam.org/content/v1/search/beacons/"
-  static let SLUG_BASE_URL: String = "https://tengam.org/"
   static let RADIUS: Int = 50
 
   static func resolveLocation(lat: Double, lon: Double, callback: (Array<JSON> -> Void)!) {
@@ -41,13 +40,15 @@ public class NetworkResolver {
   private static func filterJSON(json: JSON) -> Array<JSON> {
     var result: Array<JSON> = Array()
     for item in json.arrayValue {
-      if let shortUrl = item["short_url"].string {
-        result.append(JSON(["url": shortUrl, "channel_id": item["channel_id"].string!]))
-      }
-      else if let slug = item["slug"].string {
-        let url: String = "\(SLUG_BASE_URL)\(slug)"
-        result.append(JSON(["url": url, "channel_id": item["channel_id"].string!]))
-      }
+      let shortUrl = item["short_url"].string!
+      let latPath: [JSONSubscriptType] = ["location", "latitude"]
+      let longPath: [JSONSubscriptType] = ["location", "longitude"]
+      result.append(JSON([
+        "url": shortUrl,
+        "channel_id": item["channel_id"].string!,
+        "latitude": item[latPath].number!,
+        "longitude": item[longPath].number!
+      ]))
     }
 
     return result

--- a/MagnetScannerIOS/ScannerGeolocation.swift
+++ b/MagnetScannerIOS/ScannerGeolocation.swift
@@ -77,7 +77,14 @@ class ScannerGeolocation: NSObject, CLLocationManagerDelegate, Scanner {
       result.forEach({ (json) in
         let url = json["url"].string
         let channel = json["channel_id"].string
-        let magnetItem: Dictionary<String, AnyObject> = ["url": url!, "channel_id": channel!]
+        let latitude = json["latitude"].number
+        let longitude = json["longitude"].number
+        let magnetItem: Dictionary<String, AnyObject> = [
+          "url": url!,
+          "channel_id": channel!,
+          "latitude": latitude!,
+          "longitude": longitude!
+        ]
         self.callback(magnetItem)
       })
     })


### PR DESCRIPTION
See also:
* [Android patch](https://github.com/mozilla-magnet/magnet-scanner-android/pull/20)
* [View patch](https://github.com/mozilla-magnet/magnet-client/pull/324)

I removed the code related to the deprecated `slug` property.